### PR TITLE
Use volumes exposed by dockerfile lint worker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN npm install && \
 
 RUN mkdir /sample_rules  && \
     cp sample_rules/basic_rules_atomic.yaml  sample_rules/basic_rules.yaml  sample_rules/label_rules.yaml  \
-       sample_rules/openshift.yaml  sample_rules/osbs.yaml  sample_rules/recommended_label_rules.yaml \
-       sample_rules/default_rules.yaml /sample_rules
+       sample_rules/openshift.yaml  sample_rules/osbs.yaml  sample_rules/recommended_label_rules.yaml /sample_rules
+       # sample_rules/default_rules.yaml /sample_rules
 
 
 WORKDIR /root/
 LABEL RUN docker run -it --rm --privileged -v `pwd`:/root/ -v /var/run/docker.sock:/var/run/docker.sock --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE dockerfile_lint
 
-CMD /bin/bash
+ENTRYPOINT ["dockerfile_lint", "-f", "/root/scan/Dockerfile", "-r", "/opt/dockerfile_lint/config/default_rules.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN mkdir /sample_rules  && \
 WORKDIR /root/
 LABEL RUN docker run -it --rm --privileged -v `pwd`:/root/ -v /var/run/docker.sock:/var/run/docker.sock --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE dockerfile_lint
 
-ENTRYPOINT ["dockerfile_lint", "-f", "/root/scan/Dockerfile", "-r", "/opt/dockerfile_lint/config/default_rules.yaml"]
+ENTRYPOINT ["dockerfile_lint", "-f", "/tmp/scan/Dockerfile", "-r", "/opt/dockerfile_lint/config/default_rules.yaml"]

--- a/cccp.yml
+++ b/cccp.yml
@@ -1,0 +1,2 @@
+job-id: dockerfile-lint
+


### PR DESCRIPTION
We now spin up this container from inside a container by sharing volumes
of the base container. Base container contains Dockerfile at `/tmp/scan`
so, the path has to be changed for this image as well